### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd stormbringer
 Create a new Heroku app with the Go buildpack:
 
 ```
-heroku apps:create [NAME] --buildpack https://github.com/heroku/heroku-buildpack-go
+heroku apps:create [NAME]
 ```
 
 Set the following config vars:


### PR DESCRIPTION
The buildpack url isn't needed anymore (https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku) as we'll detect the app as a go app and use the buildpack.
